### PR TITLE
Enabling encoding for fhir export

### DIFF
--- a/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -3606,6 +3607,7 @@ public class BB2RIFExporter {
     private String bbFieldSeparator = "|";
     private final Path path;
     private final Class<E> clazz;
+    private Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
 
     /**
      * Construct a new instance. Fields will be separated using the default '|' character.
@@ -3651,7 +3653,7 @@ public class BB2RIFExporter {
      */
     private void writeLine(String... fields) {
       String line = String.join(bbFieldSeparator, fields);
-      Exporter.appendToFile(path, line);
+      Exporter.appendToFile(path, line, charset);
     }
 
     /**

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -4,9 +4,12 @@ import ca.uhn.fhir.parser.IParser;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -374,7 +377,7 @@ public abstract class Exporter {
         if (writer == null) {
           try {
             writer = new PrintWriter(
-              new BufferedWriter(new FileWriter(file.toFile(), true), FILE_BUFFER_SIZE)
+              new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.toFile(), true), StandardCharsets.UTF_8), FILE_BUFFER_SIZE)
             );
           } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -9,6 +9,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,6 +71,7 @@ public abstract class Exporter {
         !Config.get("generate.terminology_service_url", "").isEmpty();
     private BlockingQueue<String> recordQueue;
     private SupportedFhirVersion fhirVersion;
+    private Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
 
     public ExporterRuntimeOptions() {
       yearsOfHistory = Integer.parseInt(Config.get("exporter.years_of_history"));
@@ -197,7 +199,7 @@ public abstract class Exporter {
           String filename = entry.getResource().getResourceType().toString() + ".ndjson";
           Path outFilePath = outDirectory.toPath().resolve(filename);
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          appendToFile(outFilePath, entryJson);
+          appendToFile(outFilePath, entryJson, options.charset);
         }
       } else {
         String bundleJson = FhirStu3.convertToFHIRJson(person, stopTime);
@@ -214,7 +216,7 @@ public abstract class Exporter {
           String filename = entry.getResource().getResourceName() + ".ndjson";
           Path outFilePath = outDirectory.toPath().resolve(filename);
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          appendToFile(outFilePath, entryJson);
+          appendToFile(outFilePath, entryJson, options.charset);
         }
       } else {
         String bundleJson = FhirDstu2.convertToFHIRJson(person, stopTime);
@@ -231,7 +233,7 @@ public abstract class Exporter {
           String filename = entry.getResource().getResourceType().toString() + ".ndjson";
           Path outFilePath = outDirectory.toPath().resolve(filename);
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          appendToFile(outFilePath, entryJson);
+          appendToFile(outFilePath, entryJson, options.charset);
         }
       } else {
         String bundleJson = FhirR4.convertToFHIRJson(person, stopTime);
@@ -368,7 +370,7 @@ public abstract class Exporter {
    * @param file Path to the new file.
    * @param contents The contents of the file.
    */
-  static void appendToFile(Path file, String contents) {
+  static void appendToFile(Path file, String contents, Charset charset) {
     PrintWriter writer = fileWriters.get(file);
 
     if (writer == null) {
@@ -377,7 +379,7 @@ public abstract class Exporter {
         if (writer == null) {
           try {
             writer = new PrintWriter(
-              new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.toFile(), true), StandardCharsets.UTF_8), FILE_BUFFER_SIZE)
+              new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file.toFile(), true), charset), FILE_BUFFER_SIZE)
             );
           } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterDstu2.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.Table;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Map;
@@ -22,6 +23,7 @@ import org.mitre.synthea.world.agents.Provider;
 
 public abstract class FhirPractitionerExporterDstu2 {
 
+  private static Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
   private static final String EXTENSION_URI =
       "http://synthetichealth.github.io/synthea/utilization-encounters-extension";
 
@@ -68,7 +70,7 @@ public abstract class FhirPractitionerExporterDstu2 {
         Path outFilePath = outputFolder.toPath().resolve("Practitioner." + stop + ".ndjson");
         for (Bundle.Entry entry : bundle.getEntry()) {
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          Exporter.appendToFile(outFilePath, entryJson);
+          Exporter.appendToFile(outFilePath, entryJson, charset);
         }
       } else {
         parser = parser.setPrettyPrint(true);

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.Table;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Map;
@@ -23,6 +24,7 @@ import org.mitre.synthea.world.agents.Provider;
 
 public abstract class FhirPractitionerExporterR4 {
 
+  private static Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
   private static final String EXTENSION_URI =
       "http://synthetichealth.github.io/synthea/utilization-encounters-extension";
   private static final String PROC_EXTENSION_URI =
@@ -78,9 +80,9 @@ public abstract class FhirPractitionerExporterR4 {
         for (BundleEntryComponent entry : bundle.getEntry()) {
           String entryJson = parser.encodeResourceToString(entry.getResource());
           if (entry.getResource().getResourceType() == ResourceType.Practitioner) {
-            Exporter.appendToFile(pracFilePath, entryJson);
+            Exporter.appendToFile(pracFilePath, entryJson, charset);
           } else {
-            Exporter.appendToFile(roleFilePath, entryJson);
+            Exporter.appendToFile(roleFilePath, entryJson, charset);
           }
         }
       } else {

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterStu3.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.Table;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.mitre.synthea.world.agents.Provider;
 
 public abstract class FhirPractitionerExporterStu3 {
 
+  private static Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
   private static final String EXTENSION_URI =
       "http://synthetichealth.github.io/synthea/utilization-encounters-extension";
 
@@ -67,7 +69,7 @@ public abstract class FhirPractitionerExporterStu3 {
         Path outFilePath = outputFolder.toPath().resolve("Practitioner." + stop + ".ndjson");
         for (BundleEntryComponent entry : bundle.getEntry()) {
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          Exporter.appendToFile(outFilePath, entryJson);
+          Exporter.appendToFile(outFilePath, entryJson, charset);
         }
       } else {
         parser = parser.setPrettyPrint(true);

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterDstu2.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.Table;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -19,6 +20,7 @@ import org.mitre.synthea.world.agents.Provider;
 
 public abstract class HospitalExporterDstu2 {
 
+  private static Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
   private static final String SYNTHEA_URI = "http://synthetichealth.github.io/synthea/";
 
   /**
@@ -52,7 +54,7 @@ public abstract class HospitalExporterDstu2 {
         Path outFilePath = outputFolder.toPath().resolve("Organization." + stop + ".ndjson");
         for (Bundle.Entry entry : bundle.getEntry()) {
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          Exporter.appendToFile(outFilePath, entryJson);
+          Exporter.appendToFile(outFilePath, entryJson, charset);
         }
       } else {
         parser = parser.setPrettyPrint(true);

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.Table;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -21,6 +22,7 @@ import org.mitre.synthea.world.agents.Provider;
 
 public abstract class HospitalExporterR4 {
 
+  private static Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
   private static final String SYNTHEA_URI = "http://synthetichealth.github.io/synthea/";
 
   /**
@@ -58,9 +60,9 @@ public abstract class HospitalExporterR4 {
         for (BundleEntryComponent entry : bundle.getEntry()) {
           String entryJson = parser.encodeResourceToString(entry.getResource());
           if (entry.getResource().getResourceType() == ResourceType.Organization) {
-            Exporter.appendToFile(orgFilePath, entryJson);
+            Exporter.appendToFile(orgFilePath, entryJson, charset);
           } else {
-            Exporter.appendToFile(locFilePath, entryJson);
+            Exporter.appendToFile(locFilePath, entryJson, charset);
           }
         }
       } else {

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterStu3.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterStu3.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.parser.IParser;
 import com.google.common.collect.Table;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -19,6 +20,7 @@ import org.mitre.synthea.world.agents.Provider;
 
 public abstract class HospitalExporterStu3 {
 
+  private static Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
   private static final String SYNTHEA_URI = "http://synthetichealth.github.io/synthea/";
 
   /**
@@ -52,7 +54,7 @@ public abstract class HospitalExporterStu3 {
         Path outFilePath = outputFolder.toPath().resolve("Organization." + stop + ".ndjson");
         for (BundleEntryComponent entry : bundle.getEntry()) {
           String entryJson = parser.encodeResourceToString(entry.getResource());
-          Exporter.appendToFile(outFilePath, entryJson);
+          Exporter.appendToFile(outFilePath, entryJson, charset);
         }
       } else {
         parser = parser.setPrettyPrint(true);


### PR DESCRIPTION
- Honors the configuration for encoding. If no encoding is configured, defaults to UTF-8